### PR TITLE
Ignore builtin typedefs, e.g., __uint128_t

### DIFF
--- a/src/misra/UnusedTypeCheck.cpp
+++ b/src/misra/UnusedTypeCheck.cpp
@@ -24,6 +24,10 @@ void UnusedTypeCheck::check(const MatchFinder::MatchResult &Result) {
     return;
   }
 
+  if (MatchedDecl->isImplicit()) {
+     return;
+  }
+
   if (MatchedDecl->getMostRecentDecl()->isReferenced()) {
     return;
   }


### PR DESCRIPTION
This removes unwanted warnings for, e.g., __uint128_t, __builtin_va_list, etc.